### PR TITLE
Escaping . to : in timestamp

### DIFF
--- a/frontend/src/components/SearchField.tsx
+++ b/frontend/src/components/SearchField.tsx
@@ -42,9 +42,9 @@ async function filterResults(term) {
 
 async function fetchingData(query: string) {
   try {
-    const response = await axios.get(
-      import.meta.env.VITE_SEARCH_API_URL + `/search?query=${query}`
-    );
+    // const path = "http://localhost:8081";
+    const path = import.meta.env.VITE_SEARCH_API_URL;
+    const response = await axios.get(path + `/search?query=${query}`);
     localStorage.setItem("response", JSON.stringify(response.data.results));
     return response.data.results;
   } catch (error) {

--- a/search-esdb-service/internal/csv/csv.go
+++ b/search-esdb-service/internal/csv/csv.go
@@ -86,6 +86,10 @@ func insertDataFromCSV(filePath string, fileName string) error {
 			record[i] = strings.ReplaceAll(record[i], "\n", " ")
 		}
 
+		// Escape . to : in record[2] and record[3] (starttime and endtime)
+		record[2] = strings.ReplaceAll(record[2], ".", ":")
+		record[3] = strings.ReplaceAll(record[3], ".", ":")
+
 		// Assuming your CSV columns are in the order: Question, Answe``r, StartTime, EndTime
 		qar := &dto.QARecord{
 			YoutubeURL: fileName,

--- a/search-esdb-service/internal/dto/record.go
+++ b/search-esdb-service/internal/dto/record.go
@@ -1,9 +1,15 @@
 package dto
 
+import "fmt"
+
 type QARecord struct {
 	YoutubeURL string
 	Question   string
 	Answer     string
 	StartTime  string
 	EndTime    string
+}
+
+func (q *QARecord) ToString() string {
+	return fmt.Sprintf("URL %v Question %v Answer %v StartTime %v EndTime %v", q.YoutubeURL, q.Question, q.Answer, q.StartTime, q.EndTime)
 }

--- a/search-esdb-service/internal/es/crud.go
+++ b/search-esdb-service/internal/es/crud.go
@@ -33,7 +33,6 @@ func BulkInsert(qars []*dto.QARecord) {
 	start := time.Now().UTC()
 
 	// Loop over the collection
-	//
 	for order, a := range qars {
 		// Prepare the data payload: encode article to JSON
 		//

--- a/search-esdb-service/internal/es/esConnect.go
+++ b/search-esdb-service/internal/es/esConnect.go
@@ -84,7 +84,7 @@ func checkClusterHealth(client *elasticsearch.Client) {
 	}
 
 	// Print the cluster health information
-	fmt.Println("Cluster Health:")
+	fmt.Println("Elastic Cluster Health:")
 	fmt.Println("---------------")
 	fmt.Printf("Status: %s\n", res.Status())
 

--- a/search-esdb-service/internal/record/record.go
+++ b/search-esdb-service/internal/record/record.go
@@ -7,7 +7,7 @@ func GenerateUniqueDocuments(duplicateDocument []map[string]interface{})  []map[
 	// Filter duplicates and store unique documents in the map
 	for _, doc := range duplicateDocument {
 		// Use a unique identifier as the key, e.g., the document's ID or another field
-		identifier := doc["id"].(string) // Replace "id" with your actual unique identifier field
+		identifier := doc["id"].(string)
 		uniqueDocuments[identifier] = doc
 	}
 


### PR DESCRIPTION
1. Escaping  `.` to `:` in timestamp for fixing a bug when playing video
2. Rename files
3. Remove unnecessary comments